### PR TITLE
Modifications to population delimiters

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -359,7 +359,7 @@ Welcome to industrial, cultural, administrative, university and sport's center o
     <paper-material elevation="1">
 <h3>Population in Gorazde</h3>
     <p class="paper-font-body2" align="justify">
-    According to the latest census which was held in 2013, Gorazde had 12.512 citizens.
+    According to the latest census which was held in 2013, Gorazde had 12 512 citizens.
     </p>
     </paper-material>
     
@@ -512,28 +512,28 @@ Which currency is used in Gorazde?
             
                <p class="paper-font-body1">During <b>1879</b> there was organized first census of population in Bosnia and Herzegovina, from Austo - Hungarian government in Bosnia and Herzegovina. In that time Gorazde has had <b>846</b> citizens.</p>
                 
-                <p class="paper-font-body1">During the census from <b>1885</b> of population in Gorazde, there was <b>1.226</b> citizens.</p>
+                <p class="paper-font-body1">During the census from <b>1885</b> of population in Gorazde, there was <b>1 226</b> citizens.</p>
             
-            <p class="paper-font-body1">During the census from <b>1910</b> of population in Gorazde, there was <b>1.460</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1910</b> of population in Gorazde, there was <b>1 460</b> citizens.</p>
             
-            <p class="paper-font-body1">During the census from <b>1921</b> of population in Gorazde, there was <b>1.226</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1921</b> of population in Gorazde, there was <b>1 226</b> citizens.</p>
            
-            <p class="paper-font-body1">During the census from <b>1931</b> of population in Gorazde, there was <b>1.226</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1931</b> of population in Gorazde, there was <b>1 226</b> citizens.</p>
             
-            <p class="paper-font-body1">During the census from <b>1948</b> of population in Gorazde, there was <b>2.487</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1948</b> of population in Gorazde, there was <b>2 487</b> citizens.</p>
             
-            <p class="paper-font-body1">During the census from <b>1953</b> of population in Gorazde, there was <b>4.485</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1953</b> of population in Gorazde, there was <b>4 485</b> citizens.</p>
             
-            <p class="paper-font-body1">During the census from <b>1961</b> of population in Gorazde, there was <b>8.812</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1961</b> of population in Gorazde, there was <b>8 812</b> citizens.</p>
                
-            <p class="paper-font-body1">During the census from <b>1971</b> of population in Gorazde, there was <b>9.482</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1971</b> of population in Gorazde, there was <b>9 482</b> citizens.</p>
             </p>
         
-            <p class="paper-font-body1">During the census from <b>1981</b> of population in Gorazde, there was <b>13.022</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1981</b> of population in Gorazde, there was <b>13 022</b> citizens.</p>
              
-            <p class="paper-font-body1">During the census from <b>1991</b> of population in Gorazde, there was <b>19.573</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1991</b> of population in Gorazde, there was <b>19 573</b> citizens.</p>
         
-            <p class="paper-font-body1">During the census from <b>2013</b> of population in Gorazde, there was <b>12.512</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>2013</b> of population in Gorazde, there was <b>12 512</b> citizens.</p>
         <img src="http://placehold.it/500x100">  
         
         </paper-material>

--- a/app/index.html
+++ b/app/index.html
@@ -359,7 +359,7 @@ Welcome to industrial, cultural, administrative, university and sport's center o
     <paper-material elevation="1">
 <h3>Population in Gorazde</h3>
     <p class="paper-font-body2" align="justify">
-    According to the latest census which was held in 2013, Gorazde had 12 512 citizens.
+    According to the latest census which was held in 2013, Gorazde had 12,512 citizens.
     </p>
     </paper-material>
     
@@ -512,28 +512,28 @@ Which currency is used in Gorazde?
             
                <p class="paper-font-body1">During <b>1879</b> there was organized first census of population in Bosnia and Herzegovina, from Austo - Hungarian government in Bosnia and Herzegovina. In that time Gorazde has had <b>846</b> citizens.</p>
                 
-                <p class="paper-font-body1">During the census from <b>1885</b> of population in Gorazde, there was <b>1 226</b> citizens.</p>
+                <p class="paper-font-body1">During the census from <b>1885</b> of population in Gorazde, there was <b>1,226</b> citizens.</p>
             
-            <p class="paper-font-body1">During the census from <b>1910</b> of population in Gorazde, there was <b>1 460</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1910</b> of population in Gorazde, there was <b>1,460</b> citizens.</p>
             
-            <p class="paper-font-body1">During the census from <b>1921</b> of population in Gorazde, there was <b>1 226</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1921</b> of population in Gorazde, there was <b>1,226</b> citizens.</p>
            
-            <p class="paper-font-body1">During the census from <b>1931</b> of population in Gorazde, there was <b>1 226</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1931</b> of population in Gorazde, there was <b>1,226</b> citizens.</p>
             
-            <p class="paper-font-body1">During the census from <b>1948</b> of population in Gorazde, there was <b>2 487</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1948</b> of population in Gorazde, there was <b>2,487</b> citizens.</p>
             
-            <p class="paper-font-body1">During the census from <b>1953</b> of population in Gorazde, there was <b>4 485</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1953</b> of population in Gorazde, there was <b>4,485</b> citizens.</p>
             
-            <p class="paper-font-body1">During the census from <b>1961</b> of population in Gorazde, there was <b>8 812</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1961</b> of population in Gorazde, there was <b>8,812</b> citizens.</p>
                
-            <p class="paper-font-body1">During the census from <b>1971</b> of population in Gorazde, there was <b>9 482</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1971</b> of population in Gorazde, there was <b>9,482</b> citizens.</p>
             </p>
         
-            <p class="paper-font-body1">During the census from <b>1981</b> of population in Gorazde, there was <b>13 022</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1981</b> of population in Gorazde, there was <b>13,022</b> citizens.</p>
              
-            <p class="paper-font-body1">During the census from <b>1991</b> of population in Gorazde, there was <b>19 573</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>1991</b> of population in Gorazde, there was <b>19,573</b> citizens.</p>
         
-            <p class="paper-font-body1">During the census from <b>2013</b> of population in Gorazde, there was <b>12 512</b> citizens.</p>
+            <p class="paper-font-body1">During the census from <b>2013</b> of population in Gorazde, there was <b>12,512</b> citizens.</p>
         <img src="http://placehold.it/500x100">  
         
         </paper-material>


### PR DESCRIPTION
Testing pull-requests. Not a super-important change. 

English-speakers could get confused at the use of a period as a delimiter (example: 12.349), as they typically use commas (example: 12,349).

Maybe you want to use commas or spaces? See [digit grouping](https://en.wikipedia.org/wiki/Decimal_mark#Digit_grouping)?
